### PR TITLE
Price belief

### DIFF
--- a/elixir/eco/config/config.exs
+++ b/elixir/eco/config/config.exs
@@ -30,8 +30,8 @@ use Mix.Config
 #     import_config "#{Mix.env}.exs"
 
 config(:eco, [
-  {:max_labour, 1000},
-  {:number_of_bots, 50},
+  {:max_labour, 100},
+  {:number_of_bots, 2},
   {:price_sigma, 1},
   {:products,
    %{
@@ -45,7 +45,7 @@ config(:eco, [
        }
      },
      "calories" => %{
-       :labour_cost => 0.1,
+       :labour_cost => 1,
        :class => :food,
        :raw => true,
        :food_value => 1

--- a/elixir/eco/config/config.exs
+++ b/elixir/eco/config/config.exs
@@ -31,7 +31,7 @@ use Mix.Config
 
 config(:eco, [
   {:max_labour, 100},
-  {:number_of_bots, 2},
+  {:number_of_bots, 20},
   {:price_sigma, 1},
   {:products,
    %{

--- a/elixir/eco/config/config.exs
+++ b/elixir/eco/config/config.exs
@@ -32,6 +32,7 @@ use Mix.Config
 config(:eco, [
   {:max_labour, 1000},
   {:number_of_bots, 50},
+  {:price_sigma, 1},
   {:products,
    %{
      "chicken" => %{

--- a/elixir/eco/lib/actor_utils.ex
+++ b/elixir/eco/lib/actor_utils.ex
@@ -40,4 +40,27 @@ defmodule ActorUtils do
 
     {id, amount}
   end
+
+  def spread_ask(marketPid, prodId, amount, meanPrice, bucketSize, state) do
+    generate_bucket_list(amount, bucketSize)
+    |> Enum.each(fn(bucket) -> 
+      ppu = :rstats.rnormal(meanPrice, 1)
+      askId = TurnMarket.ask(marketPid, prodId, bucket, ppu)
+      SalesTracker.reg_ask(state.tracker_pid, askId, ppu, bucket)
+    end)
+  end
+
+  defp generate_bucket_list(amount, bucketSize) do
+    generate_bucket_list([], amount, bucketSize)
+  end
+
+  defp generate_bucket_list(buckets, 0, _bucketSize) do
+    buckets
+  end
+
+  defp generate_bucket_list(buckets, amount, bucketSize) do
+    newBucket = min(amount, bucketSize)
+    newAmount = amount - newBucket
+    generate_bucket_list([newAmount | buckets], newAmount, bucketSize)
+  end
 end

--- a/elixir/eco/lib/actor_utils.ex
+++ b/elixir/eco/lib/actor_utils.ex
@@ -44,9 +44,9 @@ defmodule ActorUtils do
   def spread_ask(marketPid, prodId, amount, meanPrice, bucketSize, state) do
     generate_bucket_list(amount, bucketSize)
     |> Enum.each(fn(bucket) -> 
-      ppu = :rstats.rnormal(meanPrice, 1)
+      ppu = :rstats.rnormal(meanPrice, 10)
       askId = TurnMarket.ask(marketPid, prodId, bucket, ppu)
-      SalesTracker.reg_ask(state.tracker_pid, askId, ppu, bucket)
+      SalesTracker.reg_ask(state.tracker_pid, askId, ppu, bucket, prodId)
     end)
   end
 
@@ -54,13 +54,13 @@ defmodule ActorUtils do
     generate_bucket_list([], amount, bucketSize)
   end
 
-  defp generate_bucket_list(buckets, 0, _bucketSize) do
-    buckets
-  end
-
-  defp generate_bucket_list(buckets, amount, bucketSize) do
+  defp generate_bucket_list(buckets, amount, bucketSize) when amount > 0 do
     newBucket = min(amount, bucketSize)
     newAmount = amount - newBucket
-    generate_bucket_list([newAmount | buckets], newAmount, bucketSize)
+    generate_bucket_list([newBucket | buckets], newAmount, bucketSize)
+  end
+
+  defp generate_bucket_list(buckets, _amount, _bucketSize) do
+    buckets
   end
 end

--- a/elixir/eco/lib/actor_utils.ex
+++ b/elixir/eco/lib/actor_utils.ex
@@ -50,6 +50,15 @@ defmodule ActorUtils do
     end)
   end
 
+  def normal_random_above_zero(mean, sigma) do
+    value = :rstats.rnormal(mean, sigma)
+    if value >= 0 do
+      value
+    else
+      0
+    end
+  end
+
   defp generate_bucket_list(amount, bucketSize) do
     generate_bucket_list([], amount, bucketSize)
   end

--- a/elixir/eco/lib/bot.ex
+++ b/elixir/eco/lib/bot.ex
@@ -56,8 +56,6 @@ defmodule Bot do
         end
       end)
 
-      IO.inspect(priceBeliefs)
-
       GenServer.stop(state.tracker_pid)
       priceBeliefs
     else
@@ -160,7 +158,6 @@ defmodule Bot do
           {:ok, nil} ->
             :rand.uniform() * 10
           {:ok, value} ->
-            IO.inspect(value)
             :rstats.rnormal(value, 1)
         end
         ActorUtils.spread_ask(marketPid, prodId, amount, meanPrice, 10, state)
@@ -194,7 +191,6 @@ defmodule Bot do
   end
 
   def terminate(_, _) do
-    IO.puts("bot terminated . . .")
     :ok
   end
 end

--- a/elixir/eco/lib/bot.ex
+++ b/elixir/eco/lib/bot.ex
@@ -134,11 +134,15 @@ defmodule Bot do
     |> Enum.each(fn
       {_, 0} ->
         :ok
-
       {prodId, amount} ->
-        ppu = :rand.uniform() * 10
-        askId = TurnMarket.ask(marketPid, prodId, amount, ppu)
-        SalesTracker.reg_ask(state.tracker_pid, askId, ppu, amount)
+        meanPrice = case Map.fetch(state.price_beliefs, prodId) do
+          :error ->
+            :rand.uniform() * 10
+          {:ok, value} ->
+            :rstats.rnormal(value, 1)
+        end
+
+        ActorUtils.spread_ask(marketPid, prodId, amount, meanPrice, 10, state)
     end)
   end
 

--- a/elixir/eco/lib/bot.ex
+++ b/elixir/eco/lib/bot.ex
@@ -158,7 +158,7 @@ defmodule Bot do
           {:ok, nil} ->
             :rand.uniform() * 10
           {:ok, value} ->
-            :rstats.rnormal(value, 1)
+            ActorUtils.normal_random_above_zero(value, 1)
         end
         ActorUtils.spread_ask(marketPid, prodId, amount, meanPrice, 10, state)
     end)

--- a/elixir/eco/lib/bot.ex
+++ b/elixir/eco/lib/bot.ex
@@ -106,7 +106,13 @@ defmodule Bot do
   def place_food_bids([ask | rest], labourNeeded, money, marketPid)
       when labourNeeded > 0 and money > 0 do
     foodValue = Map.get(Application.get_env(:eco, :products), ask.product_id)[:food_value]
-    max = min(ask.amount, trunc(money / ask.ppu))
+
+    # if price is 0, buy everything
+    max = if ask.ppu == 0 do
+      ask.amount
+    else
+      min(ask.amount, trunc(money / ask.ppu))
+    end
 
     if max > 0 do
       spend = max * ask.ppu

--- a/elixir/eco/lib/controller.ex
+++ b/elixir/eco/lib/controller.ex
@@ -66,7 +66,7 @@ defmodule Controller do
     {:noreply, %{state | :money => state.money - paid, :inventory => newInventory}}
   end
 
-  def handle_info({:sold, productId, amount, ppu}, state) do
+  def handle_info({:sold, _askId, productId, amount, ppu}, state) do
     newAmount = state.created[productId] - amount
     newCreated = %{state.created | productId => newAmount}
     {:noreply, %{state | :money => state.money + amount * ppu, :created => newCreated}}

--- a/elixir/eco/lib/sales_tracker.ex
+++ b/elixir/eco/lib/sales_tracker.ex
@@ -17,14 +17,27 @@ defmodule SalesTracker do
     {:ok, %SalesTracker{}}
   end
 
-  def reg_ask(pId, askId, ppu, amount) do
-    GenServer.cast(pId, {:reg_ask, askId, ppu, amount})
+  def reg_ask(trackerPid, askId, ppu, amount, productId) do
+    GenServer.cast(trackerPid, {:reg_ask, askId, ppu, amount, productId})
     :ok
   end
 
-  def reg_sale(pId, askId, amount) do
-    GenServer.cast(pId, {:reg_sale, askId, amount})
+  def reg_sale(trackerPid, askId, amount) do
+    GenServer.cast(trackerPid, {:reg_sale, askId, amount})
     :ok
+  end
+
+  def get_most_successfull_price_for_product(trackerPid, productId) do
+    case GenServer.call(trackerPid, {:most_succ_price, productId}) do
+      nil ->
+        nil
+      askData ->
+        askData.ppu
+    end
+  end
+
+  def get_product_ids(trackerPid) do
+    GenServer.call(trackerPid, :uniq_product_ids)
   end
 
   def handle_cast({:reg_sale, askId, amount}, state) do
@@ -35,11 +48,35 @@ defmodule SalesTracker do
     {:noreply, %{state | asks_sales_data: data}}
   end
 
-  def handle_cast({:reg_ask, askId, ppu, amount}, state) do
+  def handle_cast({:reg_ask, askId, ppu, amount, productId}, state) do
     data = state.asks_sales_data
-    |> Map.put(askId, %{ppu: ppu, amount: amount, sold: 0})
+    |> Map.put(askId, %{ppu: ppu, amount: amount, sold: 0, prod_id: productId})
 
     {:noreply, %{state | asks_sales_data: data}}
+  end
+
+  def handle_call({:most_succ_price, productId}, _from, state) do
+    res = state.asks_sales_data
+    |> Enum.reduce([], fn({_askId, %{prod_id: prodId} = askData}, acc) ->
+      if prodId == productId do
+        [askData | acc]
+      else
+        acc
+      end
+    end)
+    |> Enum.sort(&(&1.ppu > &2.ppu))
+    |> Enum.find(&(0 == (&1[:amount] - &1[:sold])))
+
+    {:reply, res, state}
+  end
+
+  def handle_call(:uniq_product_ids, _, state) do
+    prodIds = state.asks_sales_data
+    |> Stream.uniq_by(fn({_, %{prod_id: prodId}}) -> prodId end)
+    |> Stream.map(fn({_, %{prod_id: prodId}}) -> prodId end)
+    |> Enum.to_list
+
+    {:reply, prodIds, state}
   end
 
   def handle_call(_, _, state) do

--- a/elixir/eco/lib/sales_tracker.ex
+++ b/elixir/eco/lib/sales_tracker.ex
@@ -1,0 +1,60 @@
+defmodule SalesTracker do
+  @behaviour GenServer
+
+  defstruct(
+    asks_sales_data: %{}
+  )
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], [])
+  end
+
+  def start do
+    GenServer.start(__MODULE__, [], [])
+  end
+
+  def init([]) do
+    {:ok, %SalesTracker{}}
+  end
+
+  def reg_ask(pId, askId, ppu, amount) do
+    GenServer.cast(pId, {:reg_ask, askId, ppu, amount})
+    :ok
+  end
+
+  def reg_sale(pId, askId, amount) do
+    GenServer.cast(pId, {:reg_sale, askId, amount})
+    :ok
+  end
+
+  def handle_cast({:reg_sale, askId, amount}, state) do
+    sold = state.asks_sales_data[askId].sold + amount
+    asksData = state.asks_sales_data
+    data = put_in(asksData[askId].sold, sold)
+
+    {:noreply, %{state | asks_sales_data: data}}
+  end
+
+  def handle_cast({:reg_ask, askId, ppu, amount}, state) do
+    data = state.asks_sales_data
+    |> Map.put(askId, %{ppu: ppu, amount: amount, sold: 0})
+
+    {:noreply, %{state | asks_sales_data: data}}
+  end
+
+  def handle_call(_, _, state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+
+  def code_change(_, state, _) do
+    {:ok, state}
+  end
+
+  def terminate(_, _) do
+    :ok
+  end
+end

--- a/elixir/eco/lib/turn_market.ex
+++ b/elixir/eco/lib/turn_market.ex
@@ -114,7 +114,7 @@ defmodule TurnMarket do
         bid.amount
       end
 
-    send(ask.from, {:sold, ask.product_id, buyAmount, ask.ppu})
+    send(ask.from, {:sold, ask.id, ask.product_id, buyAmount, ask.ppu})
     send(bid.from, {:won, ask.product_id, buyAmount, ask.ppu})
     remaining = ask.amount - buyAmount
     newAsks = put_in(state.asks, [bid.ask_id, :amount], remaining)

--- a/elixir/eco/lib/turn_timer.ex
+++ b/elixir/eco/lib/turn_timer.ex
@@ -20,7 +20,7 @@ defmodule TurnTimer do
   def handle_info(:start_turn, state) do
     IO.puts("triggering bots")
     BotSup.tick
-    :timer.send_after 60*1000, :end_turn
+    :timer.send_after 20*1000, :end_turn
     {:noreply, state}
   end
 

--- a/elixir/eco/mix.exs
+++ b/elixir/eco/mix.exs
@@ -24,6 +24,7 @@ defmodule Eco.MixProject do
     [
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      {:rstats, "~> 1.0"},
       {:gproc, "~> 0.8.0"},
       {:uuid, "~> 1.1"},
       {:cowboy, "~> 1.0.0"},

--- a/elixir/eco/mix.lock
+++ b/elixir/eco/mix.lock
@@ -7,5 +7,6 @@
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.6.0", "90d338a44c8cd762c32d3ea324f6728445c6145b51895403854b77f1536f1617", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [:rebar3], [], "hexpm"},
+  "rstats": {:hex, :rstats, "1.0.2", "e8f39b4b678f1f62d556d5029999ffaaf5167756fd08114ac9f9a7acbbf57067", [:rebar3], [], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
- Bots keep track of sales each market turn with a sales tracker process
- bots split up sales of products into different asks and varies the price
- Sets prices around price belief distributed in a gaussian curve
- bot updates price belief for each product it tried to sell, each turn